### PR TITLE
Crowdin to git

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -24,7 +24,7 @@ steps:
   - echo "$GITHUB_PRIVATE_KEY" > "$HOME/.ssh/id_rsa"
   - chmod 0600 $HOME/.ssh/id_rsa
   - yarn install --frozen-lockfile
-  - npm run crowdin:sync
+# - npm run crowdin:sync
   - npm run deploy
   environment:
     USE_SSH: true

--- a/README.md
+++ b/README.md
@@ -43,6 +43,28 @@ TEST_USERNAME="Reto.Holz@gbsl.ch" yarn run start
 
 and make sure, that the user `Reto.Holz@gbsl.ch` exists on your local api.
 
+## Translations
+
+The translations can be found in the `i18n` folder. The `de` folder contains the german (default) translations. The `fr` folder contains the french translations.
+Update the translations with:
+
+```bash
+# for german
+yarn write-translations --locale de
+# for french
+yarn write-translations --locale fr
+```
+
+existing translations will not be overwritten, except you pass the `--overwrite` flag.
+
+After updating the translations, make sure to update the new keys (you can see in git, which keys are new...)
+
+To start docusaurus with the new translations in e.g. french, run:
+
+```bash
+yarn run start --locale fr
+```
+
 ### Build
 
 ```

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ To start docusaurus with the new translations in e.g. french, run:
 yarn run start --locale fr
 ```
 
+Checkout [Docusaurus](https://docusaurus.io/docs/i18n/tutorial) for further information.
+
 ### Build
 
 ```

--- a/cleanup-translations.js
+++ b/cleanup-translations.js
@@ -1,0 +1,15 @@
+const fs = require('fs')
+fs.readdirSync('./i18n').forEach(locale => {
+    const dir = `./i18n/${locale}`;
+    if (fs.lstatSync(dir).isDirectory()) {
+        const fFooter = `${dir}/docusaurus-theme-classic/footer.json`;
+        if (fs.existsSync(fFooter)) {
+            const footer = JSON.parse(fs.readFileSync(fFooter));
+            if ('copyright' in footer) {
+                delete footer['copyright'];
+                console.log(`[i18n/${locale}] removed 'copyright' from footer.json`);
+            }
+            fs.writeFileSync(fFooter, JSON.stringify(footer, null, 2));
+        }
+    }
+});

--- a/i18n/de/code.json
+++ b/i18n/de/code.json
@@ -104,7 +104,7 @@
     "description": "The default description for a category card in the generated index about how many items this category includes"
   },
   "theme.docs.paginator.navAriaLabel": {
-    "message": "Dokumentation Seiten Navigation",
+    "message": "Dokumentation Seiten",
     "description": "The ARIA label for the docs pagination"
   },
   "theme.docs.paginator.previous": {
@@ -193,10 +193,6 @@
   "theme.CodeBlock.wordWrapToggle": {
     "message": "Toggle word wrap",
     "description": "The title attribute for toggle word wrapping button of code block lines"
-  },
-  "theme.DocSidebarItem.toggleCollapsedCategoryAriaLabel": {
-    "message": "Umschalten der Seitenleiste mit einklappbarer Kategorie '{label}'",
-    "description": "The ARIA label to toggle the collapsible sidebar category"
   },
   "theme.NavBar.navAriaLabel": {
     "message": "Main",
@@ -302,10 +298,6 @@
     "message": "Aktionen",
     "description": "th: actions"
   },
-  "event.title": {
-    "message": "Titel",
-    "description": "for a single event: title"
-  },
   "event.kw": {
     "message": "KW",
     "description": "for a single event: kw"
@@ -313,10 +305,6 @@
   "event.weekday": {
     "message": "Wochentag",
     "description": "for a single event: weekday"
-  },
-  "event.startDate": {
-    "message": "Datum",
-    "description": "for a single event: start date"
   },
   "event.location": {
     "message": "Ort",
@@ -335,7 +323,7 @@
     "description": "for a single event: affected lessons"
   },
   "event.button.showAllLessons": {
-    "message": "Alle betroffenen Lektionen anzeigen",
+    "message": "Alle laden",
     "description": "for a single event: button to show all affected lessons"
   },
   "admin.userTable.th.email": {
@@ -362,52 +350,449 @@
     "message": "Id",
     "description": "th: id"
   },
-  "event.eventGrid.th.author": {
-    "message": "Author",
-    "description": "th: author"
+  "event.state.draft": {
+    "message": "Entwurf",
+    "description": "[noun] Event state draft"
   },
-  "event.eventGrid.th.kw": {
-    "message": "KW",
-    "description": "th: kw"
+  "event.state.review": {
+    "message": "In Prüfung",
+    "description": "[noun] Event state review"
   },
-  "event.eventGrid.th.day": {
-    "message": "Tag",
-    "description": "th: day"
+  "event.state.published": {
+    "message": "Veröffentlicht",
+    "description": "[noun] Event state published"
   },
-  "event.eventGrid.th.description": {
-    "message": "Stichworte",
-    "description": "th: description"
+  "event.state.refused": {
+    "message": "Zurückgewiesen",
+    "description": "[noun] Event state refused"
   },
-  "event.eventGrid.th.startDate": {
+  "event.state.action:draft": {
+    "message": "Entwurf",
+    "description": "[verb] request event state: draft"
+  },
+  "event.state.action:review": {
+    "message": "Prüfen",
+    "description": "[verb] request event: review"
+  },
+  "event.state.action:publish": {
+    "message": "Veröffentlichen",
+    "description": "[verb] request event: published"
+  },
+  "event.state.action:refuse": {
+    "message": "Zurückweisen",
+    "description": "[verb] request event state: refused"
+  },
+  "joi.event.start": {
     "message": "Start",
-    "description": "th: startDate"
+    "description": "Start of event"
   },
-  "event.eventGrid.th.startTime": {
-    "message": "Zeit",
-    "description": "th: startTime"
-  },
-  "event.eventGrid.th.endDate": {
+  "joi.event.end": {
     "message": "Ende",
-    "description": "th: endDate"
+    "description": "End of event"
   },
-  "event.eventGrid.th.endTime": {
+  "joi.event.end.min": {
+    "message": "Ende muss grösser oder gleich Start ({start}) sein",
+    "description": "End of event must be after start"
+  },
+  "joi.event.description": {
+    "message": "Stichworte",
+    "description": "Description of event"
+  },
+  "joi.event.description.empty": {
+    "message": "Stichworte dürfen nicht leer sein",
+    "description": "Description of event must not be empty"
+  },
+  "joi.string.empty": {
+    "message": "{{#label}} darf nicht leer sein",
+    "description": "Joi validation error for empty string"
+  },
+  "joi.number.base": {
+    "message": "{{#label}} Muss eine Zahl sein",
+    "description": "Joi validation error for number base"
+  },
+  "joi.any.invalid": {
+    "message": "{{#label}} Wert ungültig",
+    "description": "Joi validation error for any invalid"
+  },
+  "joi.any.required": {
+    "message": "{{#label}} Darf nicht leer sein",
+    "description": "Joi validation error for required value"
+  },
+  "joi.date.base": {
+    "message": "{{#label}} muss grösser oder gleich {{:#limit}} sein",
+    "description": "Joi validation error for date min"
+  },
+  "admin.tab.users": {
+    "message": "Users"
+  },
+  "admin.tab.Semester": {
+    "message": "Semester"
+  },
+  "admin.section.semester": {
+    "message": "Semester",
+    "description": "Section Title semester"
+  },
+  "admin.button.semester.hinzufugen.title": {
+    "message": "Semester Hinzufügen",
+    "description": "Button Title Semester Hinzufügen"
+  },
+  "admin.button.semester.hinzufuge.text": {
+    "message": "Neues Semester",
+    "description": "Button Text Neues Semester"
+  },
+  "admin.tab.departments": {
+    "message": "Abteilungen"
+  },
+  "admin.tab.import": {
+    "message": "Import"
+  },
+  "admin.section.import.title": {
+    "message": "Excel Import",
+    "description": "admin.section.import.title"
+  },
+  "admin.section.import.subtitle": {
+    "message": "Importiere Daten aus Excel-Dateien.",
+    "description": "admin.section.import.subtitle"
+  },
+  "admin.tab.reg-periods": {
+    "message": "Registrierungs Perioden"
+  },
+  "calendar.button.nextWeek": {
+    "message": "Nächste",
+    "description": "button to show the next week on the calendar"
+  },
+  "calendar.button.previousWeek": {
+    "message": "Vorherige",
+    "description": "button to show the previous week on the calendar"
+  },
+  "calendar.button.today": {
+    "message": "Heute",
+    "description": "button to show today on the calendar"
+  },
+  "calendar.button.month": {
+    "message": "Monat",
+    "description": "button to show the calendar by month"
+  },
+  "calendar.button.week": {
+    "message": "Woche",
+    "description": "button to show the calendar by week"
+  },
+  "calendar.button.day": {
+    "message": "Tag",
+    "description": "button to show the calendar by day"
+  },
+  "calendar.button.agenda": {
+    "message": "Agenda",
+    "description": "button to show the calendar as list"
+  },
+  "calendar.field.date": {
+    "message": "Datum",
+    "description": "title of the table for the date"
+  },
+  "calendar.field.time": {
     "message": "Zeit",
-    "description": "th: endTime"
+    "description": "title of the table for the time"
   },
-  "event.eventGrid.th.location": {
-    "message": "Ort",
-    "description": "th: location"
+  "calendar.field.event": {
+    "message": "Event",
+    "description": "title of the table for the event"
   },
-  "event.eventGrid.th.departments": {
-    "message": "Abteilungen",
-    "description": "th: departments"
+  "calendar.message.noevent": {
+    "message": "Keine Events in diesem Zeitraum",
+    "description": "message if no event in time range"
   },
-  "event.eventGrid.th.classes": {
-    "message": "Klassen",
-    "description": "th: classes"
+  "calendar.button.tomorrow": {
+    "message": "Morgen",
+    "description": "button label to navigate to the next day"
   },
-  "event.eventGrid.th.descriptionLong": {
+  "calendar.button.workWeek": {
+    "message": "Arbeitswoche",
+    "description": "button label to display a work week"
+  },
+  "calendar.button.yesterday": {
+    "message": "Gestern",
+    "description": "button label to navigate to the previous day"
+  },
+  "calendar.message.allDay": {
+    "message": "Ganzer Tag",
+    "description": "message if an event spans the whole day"
+  },
+  "import.section.title": {
+    "message": "Excel Import",
+    "description": "import.section.title"
+  },
+  "import.section.subtitle": {
+    "message": "Importiere Daten aus Excel-Dateien.",
+    "description": "import.section.subtitle"
+  },
+  "my-events.tab.notpublished": {
+    "message": "Unveröffentlicht"
+  },
+  "my-events.unpublished": {
+    "message": "Unveröffentlicht",
+    "description": "text unpublished"
+  },
+  "my-events.tab.review": {
+    "message": "Review"
+  },
+  "my-events.review": {
+    "message": "Im Review",
+    "description": "text In Review"
+  },
+  "my-events.tab.admin": {
+    "message": "Admin"
+  },
+  "my-events.review.furadmin": {
+    "message": "Im ReviewReview Anfragen für Admin",
+    "description": "text In Review - wait for admin"
+  },
+  "my-events.tab.published": {
+    "message": "Veröffentlicht"
+  },
+  "my-events.published": {
+    "message": "Veröffentlicht",
+    "description": "published"
+  },
+  "my-events.tab.deleted": {
+    "message": "VeröGelöschtffentlicht"
+  },
+  "my-events.deleted": {
+    "message": "Gelöscht",
+    "description": "deleted"
+  },
+  "my-events.deleted.text": {
+    "message": "Job Löschen",
+    "description": "my-events.deleted.text"
+  },
+  "user.section.title.personal-area": {
+    "message": "Persönlicher Bereich",
+    "description": "user.section.title.personal-area"
+  },
+  "user.tab.account": {
+    "message": "Account"
+  },
+  "user.button.refresh.text": {
+    "message": "Aktualisieren",
+    "description": "user.button.refresh.text"
+  },
+  "user.tab.events": {
+    "message": "Events"
+  },
+  "user.tab.groups": {
+    "message": "Gruppen"
+  },
+  "user.tab.time-table": {
+    "message": "Stundenplan"
+  },
+  "event.AddButton.text": {
+    "message": "Neues Event",
+    "description": "AddButton text"
+  },
+  "event.description": {
+    "message": "Titel",
+    "description": "for a single event: description"
+  },
+  "event.descriptionLong": {
     "message": "Beschreibung",
-    "description": "th: descriptionLong"
+    "description": "for a single event: description long"
+  },
+  "event.versionNumber": {
+    "message": "Version",
+    "description": "for a single event: version number"
+  },
+  "event.state": {
+    "message": "Status",
+    "description": "for a single event: state"
+  },
+  "event.date": {
+    "message": "Datum",
+    "description": "for a single event: date range"
+  },
+  "event.audience": {
+    "message": "Beteiligte",
+    "description": "for a single event: class and department picker"
+  },
+  "event.requestState": {
+    "message": "Status Ändern",
+    "description": "Requesting the next state, eg. Draft -> Review"
+  },
+  "event.button.loadVersions": {
+    "message": "Versionen laden",
+    "description": "for a single event: button to load version history"
+  },
+  "user.ical.sync-button.text": {
+    "message": "Sync",
+    "description": "Button text for (re)syncing the calendar"
+  },
+  "user.ical.sync-button.title": {
+    "message": "Synchronisiere meinen Kalender",
+    "description": "Button (hover) title for (re)syncing the calendar"
+  },
+  "user.ical.outlook-button.text": {
+    "message": "Outlook",
+    "description": "Button text for adding the calendar to Outlook"
+  },
+  "user.ical.outlook-button.title": {
+    "message": "Abonniere den Kalender in Outlook",
+    "description": "Button text for adding the calendar to Outlook"
+  },
+  "admin.DepartmentTable.th.letter": {
+    "message": "Buchstabe",
+    "description": "th: department letter"
+  },
+  "admin.userTable.filter.placeholder": {
+    "message": "Filter",
+    "description": "filter: placeholder"
+  },
+  "button.open": {
+    "message": "Öffnen",
+    "description": "Button text for open button"
+  },
+  "button.save": {
+    "message": "Speichern",
+    "description": "Button to save changes"
+  },
+  "button.edit": {
+    "message": "Bearbeiten",
+    "description": "Button to edit a model"
+  },
+  "eventGrid.header.state": {
+    "message": "Zustand",
+    "description": "Label for the Event Grid Columns"
+  },
+  "eventGrid.header.isValid": {
+    "message": "Valid",
+    "description": "Label for the Event Grid Columns"
+  },
+  "eventGrid.header.select": {
+    "message": "Auswählen",
+    "description": "Label for the Event Grid Columns"
+  },
+  "eventGrid.header.kw": {
+    "message": "KW",
+    "description": "Label for the Event Grid Columns"
+  },
+  "eventGrid.header.actions": {
+    "message": "Aktionen",
+    "description": "Label for the Event Grid Columns"
+  },
+  "eventGrid.header.author": {
+    "message": "Author",
+    "description": "Label for the Event Grid Columns"
+  },
+  "eventGrid.header.day": {
+    "message": "Tag",
+    "description": "Label for the Event Grid Columns"
+  },
+  "eventGrid.header.description": {
+    "message": "Stichworte",
+    "description": "Label for the Event Grid Columns"
+  },
+  "eventGrid.header.start": {
+    "message": "Start",
+    "description": "Label for the Event Grid Columns"
+  },
+  "eventGrid.header.end": {
+    "message": "Ende",
+    "description": "Label for the Event Grid Columns"
+  },
+  "eventGrid.header.location": {
+    "message": "Ort",
+    "description": "Label for the Event Grid Columns"
+  },
+  "eventGrid.header.userGroup": {
+    "message": "Gruppe",
+    "description": "Label for the Event Grid Columns"
+  },
+  "eventGrid.header.departmens": {
+    "message": "Abteilungen",
+    "description": "Label for the Event Grid Columns"
+  },
+  "eventGrid.header.classes": {
+    "message": "Klassen",
+    "description": "Label for the Event Grid Columns"
+  },
+  "eventGrid.header.descriptionLong": {
+    "message": "Beschreibung",
+    "description": "Label for the Event Grid Columns"
+  },
+  "eventGrid.header.isDuplicate": {
+    "message": "Duplikat",
+    "description": "Label for the Event Grid Columns"
+  },
+  "event.open.title": {
+    "message": "Öffnen",
+    "description": "Button Title (hover) to open an event view"
+  },
+  "button.close.title": {
+    "message": "Fenster Schliessen",
+    "description": "Button title to close a modal"
+  },
+  "button.close": {
+    "message": "Schliessen",
+    "description": "Button text to close a modal"
+  },
+  "TeachingAffected.YES.description": {
+    "message": "Ja",
+    "description": "Yes, the teaching is affected and the class is not present"
+  },
+  "TeachingAffected.NO.description": {
+    "message": "Nein",
+    "description": "No, the teaching happens as usual"
+  },
+  "TeachingAffected.PARTIAL.description": {
+    "message": "Teilweise",
+    "description": "Only a part of the class will be present"
+  },
+  "EventAudience.ALL.description": {
+    "message": "Alle",
+    "description": "This event is for everyone, no matter wheter a lesson is affected or not"
+  },
+  "EventAudience.KLP.description": {
+    "message": "KLP",
+    "description": "Only relevant (and displayed) for class teachers"
+  },
+  "EventAudience.LP.description": {
+    "message": "LP",
+    "description": "Only relevant for teachers affected of this class (no matter wheter a lesson is affected or not)"
+  },
+  "EventAudience.STUDENTS.description": {
+    "message": "SuS",
+    "description": "Relevant for SuS only, their KLP will be informed aswell"
+  },
+  "shared.AudiencePicker": {
+    "message": "Alle Schulen",
+    "description": "Button text to toggle all schools on/off"
+  },
+  "Künftige Klassen": {
+    "message": "Künftige Klassen"
+  },
+  "shared.AudiencePicker.Department": {
+    "message": "Alle",
+    "description": "toggle all departments"
+  },
+  "theme.admonition.warning": {
+    "message": "warning",
+    "description": "The default label used for the Warning admonition (:::warning)"
+  },
+  "theme.DocSidebarItem.expandCategoryAriaLabel": {
+    "message": "Expand sidebar category '{label}'",
+    "description": "The ARIA label to expand the sidebar category"
+  },
+  "theme.DocSidebarItem.collapseCategoryAriaLabel": {
+    "message": "Collapse sidebar category '{label}'",
+    "description": "The ARIA label to collapse the sidebar category"
+  },
+  "theme.unlistedContent.title": {
+    "message": "Unlisted page",
+    "description": "The unlisted content banner title"
+  },
+  "theme.unlistedContent.message": {
+    "message": "This page is unlisted. Search engines will not index it, and only users having a direct link can access it.",
+    "description": "The unlisted content banner message"
+  },
+  "calendar.button.plus": {
+    "message": "weitere",
+    "description": "button label to show more events"
   }
 }

--- a/i18n/de/docusaurus-plugin-content-docs/current.json
+++ b/i18n/de/docusaurus-plugin-content-docs/current.json
@@ -2,5 +2,17 @@
   "version.label": {
     "message": "Next",
     "description": "The label for version current"
+  },
+  "sidebar.tutorialSidebar.category.Scenes": {
+    "message": "Scenes",
+    "description": "The label for category Scenes in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.Services": {
+    "message": "Services",
+    "description": "The label for category Services in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.ics": {
+    "message": "ics",
+    "description": "The label for category ics in sidebar tutorialSidebar"
   }
 }

--- a/i18n/de/docusaurus-theme-classic/footer.json
+++ b/i18n/de/docusaurus-theme-classic/footer.json
@@ -3,14 +3,6 @@
     "message": "Admin",
     "description": "The title of the footer links column with title=Admin in the footer"
   },
-  "link.title.Dashboard": {
-    "message": "Dashboard",
-    "description": "The title of the footer links column with title=Dashboard in the footer"
-  },
-  "link.title.More": {
-    "message": "Mehr",
-    "description": "The title of the footer links column with title=More in the footer"
-  },
   "link.item.label.Dashboard": {
     "message": "Dashboard",
     "description": "The label of footer link with label=Dashboard linking to /admin"
@@ -18,10 +10,6 @@
   "link.item.label.Import": {
     "message": "Import",
     "description": "The label of footer link with label=Import linking to /import"
-  },
-  "link.item.label.Socket.IO Admin": {
-    "message": "Socket.IO Admin",
-    "description": "The label of footer link with label=Socket.IO Admin linking to https://admin.socket.io/"
   },
   "link.item.label.GBSL": {
     "message": "GBSL",
@@ -34,5 +22,33 @@
   "link.item.label.GBJB": {
     "message": "GBJB",
     "description": "The label of footer link with label=GBJB linking to https://gfbienne.ch"
+  },
+  "link.title.Events": {
+    "message": "Events",
+    "description": "The title of the footer links column with title=Events in the footer"
+  },
+  "link.title.Links": {
+    "message": "Links",
+    "description": "The title of the footer links column with title=Links in the footer"
+  },
+  "link.item.label.Kalender": {
+    "message": "Kalender",
+    "description": "The label of footer link with label=Kalender linking to /calendar"
+  },
+  "link.item.label.Tabelle": {
+    "message": "Tabelle",
+    "description": "The label of footer link with label=Tabelle linking to /table"
+  },
+  "link.item.label.Gantt": {
+    "message": "Gantt",
+    "description": "The label of footer link with label=Gantt linking to /gantt"
+  },
+  "link.item.label.Dokumentation": {
+    "message": "Dokumentation",
+    "description": "The label of footer link with label=Dokumentation linking to /docs"
+  },
+  "link.item.label.Socket.IO Dashboard": {
+    "message": "Socket.IO Dashboard",
+    "description": "The label of footer link with label=Socket.IO Dashboard linking to https://admin.socket.io/"
   }
 }

--- a/i18n/de/docusaurus-theme-classic/navbar.json
+++ b/i18n/de/docusaurus-theme-classic/navbar.json
@@ -15,16 +15,8 @@
     "message": "Tabelle",
     "description": "Navbar item with label Tabelle"
   },
-  "item.label.GANTT": {
-    "message": "GANTT",
-    "description": "Navbar item with label GANTT"
-  },
-  "item.label.Stupla": {
-    "message": "Stupla",
-    "description": "Navbar item with label Stupla"
-  },
-  "item.label.Meine": {
-    "message": "Meine",
-    "description": "Navbar item with label Meine"
+  "item.label.Zeitachse": {
+    "message": "Zeitachse",
+    "description": "Navbar item with label Zeitachse"
   }
 }

--- a/i18n/fr/code.json
+++ b/i18n/fr/code.json
@@ -194,10 +194,6 @@
     "message": "Toggle word wrap",
     "description": "The title attribute for toggle word wrapping button of code block lines"
   },
-  "theme.DocSidebarItem.toggleCollapsedCategoryAriaLabel": {
-    "message": "Basculement de la barre latérale avec catégorie rétractable '{label}'.",
-    "description": "The ARIA label to toggle the collapsible sidebar category"
-  },
   "theme.NavBar.navAriaLabel": {
     "message": "Main",
     "description": "The ARIA label for the main navigation"
@@ -302,10 +298,6 @@
     "message": "Actions",
     "description": "th: actions"
   },
-  "event.title": {
-    "message": "Titre",
-    "description": "for a single event: title"
-  },
   "event.kw": {
     "message": "KW",
     "description": "for a single event: kw"
@@ -313,10 +305,6 @@
   "event.weekday": {
     "message": "Jour de la semaine",
     "description": "for a single event: weekday"
-  },
-  "event.startDate": {
-    "message": "Date",
-    "description": "for a single event: start date"
   },
   "event.location": {
     "message": "Lieu",
@@ -361,54 +349,6 @@
   "admin.userTable.th.id": {
     "message": "Id",
     "description": "th: id"
-  },
-  "event.eventGrid.th.author": {
-    "message": "Auteur",
-    "description": "th: author"
-  },
-  "event.eventGrid.th.kw": {
-    "message": "KW",
-    "description": "th: kw"
-  },
-  "event.eventGrid.th.day": {
-    "message": "Jour",
-    "description": "th: day"
-  },
-  "event.eventGrid.th.description": {
-    "message": "Mots-clés",
-    "description": "th: description"
-  },
-  "event.eventGrid.th.startDate": {
-    "message": "Lancement",
-    "description": "th: startDate"
-  },
-  "event.eventGrid.th.startTime": {
-    "message": "Temps",
-    "description": "th: startTime"
-  },
-  "event.eventGrid.th.endDate": {
-    "message": "Fin",
-    "description": "th: endDate"
-  },
-  "event.eventGrid.th.endTime": {
-    "message": "Temps",
-    "description": "th: endTime"
-  },
-  "event.eventGrid.th.location": {
-    "message": "Lieu",
-    "description": "th: location"
-  },
-  "event.eventGrid.th.departments": {
-    "message": "Départements",
-    "description": "th: departments"
-  },
-  "event.eventGrid.th.classes": {
-    "message": "Classes",
-    "description": "th: classes"
-  },
-  "event.eventGrid.th.descriptionLong": {
-    "message": "Description",
-    "description": "th: descriptionLong"
   },
   "event.state.draft": {
     "message": "Brouillon",
@@ -850,5 +790,9 @@
   "theme.unlistedContent.message": {
     "message": "Cette page est non répertoriée. Les moteurs de recherche ne vont pas l'indexer et seuls les utilisateurs·trices ayant un lien direct y ont accès.",
     "description": "The unlisted content banner message"
+  },
+  "calendar.button.plus": {
+    "message": "plus",
+    "description": "button label to show more events"
   }
 }

--- a/i18n/fr/code.json
+++ b/i18n/fr/code.json
@@ -409,5 +409,446 @@
   "event.eventGrid.th.descriptionLong": {
     "message": "Description",
     "description": "th: descriptionLong"
+  },
+  "event.state.draft": {
+    "message": "Brouillon",
+    "description": "[noun] Event state draft"
+  },
+  "event.state.review": {
+    "message": "En vérification",
+    "description": "[noun] Event state review"
+  },
+  "event.state.published": {
+    "message": "Publié",
+    "description": "[noun] Event state published"
+  },
+  "event.state.refused": {
+    "message": "Rejeté",
+    "description": "[noun] Event state refused"
+  },
+  "event.state.action:draft": {
+    "message": "Brouillon",
+    "description": "[verb] request event state: draft"
+  },
+  "event.state.action:review": {
+    "message": "Réviser",
+    "description": "[verb] request event: review"
+  },
+  "event.state.action:publish": {
+    "message": "Publier",
+    "description": "[verb] request event: published"
+  },
+  "event.state.action:refuse": {
+    "message": "Rejeter",
+    "description": "[verb] request event state: refused"
+  },
+  "joi.event.start": {
+    "message": "Début",
+    "description": "Start of event"
+  },
+  "joi.event.end": {
+    "message": "Fin",
+    "description": "End of event"
+  },
+  "joi.event.end.min": {
+    "message": "La date de fin doit être ultérieure ou égale à la date de début ({start})",
+    "description": "End of event must be after start"
+  },
+  "joi.event.description": {
+    "message": "Mots-clés",
+    "description": "Description of event"
+  },
+  "joi.event.description.empty": {
+    "message": "Le champ \"mots-clés\" ne doit pas être vide",
+    "description": "Description of event must not be empty"
+  },
+  "joi.string.empty": {
+    "message": "{{#label}} ne doit pas être vide",
+    "description": "Joi validation error for empty string"
+  },
+  "joi.number.base": {
+    "message": "{{#label}} doit être un nombre",
+    "description": "Joi validation error for number base"
+  },
+  "joi.any.invalid": {
+    "message": "{{#label}} contient une valeur non valable",
+    "description": "Joi validation error for any invalid"
+  },
+  "joi.any.required": {
+    "message": "{{#label}} ne doit pas être vide",
+    "description": "Joi validation error for required value"
+  },
+  "joi.date.base": {
+    "message": "{{#label}} doit être plus grand ou égal à {{:#limit}}",
+    "description": "Joi validation error for date min"
+  },
+  "admin.tab.users": {
+    "message": "Utilisateurs"
+  },
+  "admin.tab.Semester": {
+    "message": "Semestre"
+  },
+  "admin.section.semester": {
+    "message": "Semestre",
+    "description": "Section Title semester"
+  },
+  "admin.button.semester.hinzufugen.title": {
+    "message": "Ajouter un semestre",
+    "description": "Button Title Semester Hinzufügen"
+  },
+  "admin.button.semester.hinzufuge.text": {
+    "message": "Nouveau semestre",
+    "description": "Button Text Neues Semester"
+  },
+  "admin.tab.departments": {
+    "message": "Filières"
+  },
+  "admin.tab.import": {
+    "message": "Importer"
+  },
+  "admin.section.import.title": {
+    "message": "Importation pour Excel",
+    "description": "admin.section.import.title"
+  },
+  "admin.section.import.subtitle": {
+    "message": "Importer les données à partir de données Excel.",
+    "description": "admin.section.import.subtitle"
+  },
+  "admin.tab.reg-periods": {
+    "message": "Période d'enregistrement"
+  },
+  "calendar.button.nextWeek": {
+    "message": "Suivant",
+    "description": "button to show the next week on the calendar"
+  },
+  "calendar.button.previousWeek": {
+    "message": "Précédent",
+    "description": "button to show the previous week on the calendar"
+  },
+  "calendar.button.today": {
+    "message": "Aujourd'hui",
+    "description": "button to show today on the calendar"
+  },
+  "calendar.button.month": {
+    "message": "Mois",
+    "description": "button to show the calendar by month"
+  },
+  "calendar.button.week": {
+    "message": "Semaine",
+    "description": "button to show the calendar by week"
+  },
+  "calendar.button.day": {
+    "message": "Jour",
+    "description": "button to show the calendar by day"
+  },
+  "calendar.button.agenda": {
+    "message": "Agenda",
+    "description": "button to show the calendar as list"
+  },
+  "calendar.field.date": {
+    "message": "Date",
+    "description": "title of the table for the date"
+  },
+  "calendar.field.time": {
+    "message": "Horaire",
+    "description": "title of the table for the time"
+  },
+  "calendar.field.event": {
+    "message": "Évènement",
+    "description": "title of the table for the event"
+  },
+  "calendar.message.noevent": {
+    "message": "Aucun évènement dans cet intervalle de temps",
+    "description": "message if no event in time range"
+  },
+  "calendar.button.tomorrow": {
+    "message": "Demain",
+    "description": "button label to navigate to the next day"
+  },
+  "calendar.button.workWeek": {
+    "message": "Semaines de travail",
+    "description": "button label to display a work week"
+  },
+  "calendar.button.yesterday": {
+    "message": "Hier",
+    "description": "button label to navigate to the previous day"
+  },
+  "calendar.message.allDay": {
+    "message": "Toute la journée",
+    "description": "message if an event spans the whole day"
+  },
+  "import.section.title": {
+    "message": "Importation pour Excel",
+    "description": "import.section.title"
+  },
+  "import.section.subtitle": {
+    "message": "Importer des données à partir de données d'Excel.",
+    "description": "import.section.subtitle"
+  },
+  "my-events.tab.notpublished": {
+    "message": "Non publié"
+  },
+  "my-events.unpublished": {
+    "message": "Non publié",
+    "description": "text unpublished"
+  },
+  "my-events.tab.review": {
+    "message": "Révision"
+  },
+  "my-events.review": {
+    "message": "En révision",
+    "description": "text In Review"
+  },
+  "my-events.tab.admin": {
+    "message": "Administrateur"
+  },
+  "my-events.review.furadmin": {
+    "message": "En attente de la révision de l'administrateur",
+    "description": "text In Review - wait for admin"
+  },
+  "my-events.tab.published": {
+    "message": "Publié"
+  },
+  "my-events.published": {
+    "message": "Publié",
+    "description": "published"
+  },
+  "my-events.tab.deleted": {
+    "message": "VeröGelöschtffentlicht"
+  },
+  "my-events.deleted": {
+    "message": "Supprimé",
+    "description": "deleted"
+  },
+  "my-events.deleted.text": {
+    "message": "Supprimer",
+    "description": "my-events.deleted.text"
+  },
+  "user.section.title.personal-area": {
+    "message": "Espace personnel",
+    "description": "user.section.title.personal-area"
+  },
+  "user.tab.account": {
+    "message": "Compte"
+  },
+  "user.button.refresh.text": {
+    "message": "Actualiser",
+    "description": "user.button.refresh.text"
+  },
+  "user.tab.events": {
+    "message": "Événements"
+  },
+  "user.tab.groups": {
+    "message": "Groupes"
+  },
+  "user.tab.time-table": {
+    "message": "Horaire"
+  },
+  "event.AddButton.text": {
+    "message": "Nouvel événement",
+    "description": "AddButton text"
+  },
+  "event.description": {
+    "message": "Titre",
+    "description": "for a single event: description"
+  },
+  "event.descriptionLong": {
+    "message": "Description",
+    "description": "for a single event: description long"
+  },
+  "event.versionNumber": {
+    "message": "Version",
+    "description": "for a single event: version number"
+  },
+  "event.state": {
+    "message": "Statut",
+    "description": "for a single event: state"
+  },
+  "event.date": {
+    "message": "Date",
+    "description": "for a single event: date range"
+  },
+  "event.audience": {
+    "message": "Participant·e·s",
+    "description": "for a single event: class and department picker"
+  },
+  "event.requestState": {
+    "message": "Changer d’état",
+    "description": "Requesting the next state, eg. Draft -> Review"
+  },
+  "event.button.loadVersions": {
+    "message": "Charger l'historique des versions",
+    "description": "for a single event: button to load version history"
+  },
+  "user.ical.sync-button.text": {
+    "message": "Synchroniser",
+    "description": "Button text for (re)syncing the calendar"
+  },
+  "user.ical.sync-button.title": {
+    "message": "Synchroniser mon calendrier",
+    "description": "Button (hover) title for (re)syncing the calendar"
+  },
+  "user.ical.outlook-button.text": {
+    "message": "Outlook",
+    "description": "Button text for adding the calendar to Outlook"
+  },
+  "user.ical.outlook-button.title": {
+    "message": "Abonner le calendrier dans Outlook",
+    "description": "Button text for adding the calendar to Outlook"
+  },
+  "admin.DepartmentTable.th.letter": {
+    "message": "Sigle",
+    "description": "th: department letter"
+  },
+  "admin.userTable.filter.placeholder": {
+    "message": "Filtre",
+    "description": "filter: placeholder"
+  },
+  "button.open": {
+    "message": "Ouvrir",
+    "description": "Button text for open button"
+  },
+  "button.save": {
+    "message": "Enregistrer",
+    "description": "Button to save changes"
+  },
+  "button.edit": {
+    "message": "Éditer",
+    "description": "Button to edit a model"
+  },
+  "event.open.title": {
+    "message": "Ouvrir",
+    "description": "Button Title (hover) to open an event view"
+  },
+  "eventGrid.header.state": {
+    "message": "État",
+    "description": "Label for the Event Grid Columns"
+  },
+  "eventGrid.header.isValid": {
+    "message": "Valide",
+    "description": "Label for the Event Grid Columns"
+  },
+  "eventGrid.header.select": {
+    "message": "Choisir",
+    "description": "Label for the Event Grid Columns"
+  },
+  "eventGrid.header.kw": {
+    "message": "N°",
+    "description": "Label for the Event Grid Columns"
+  },
+  "eventGrid.header.actions": {
+    "message": "Actions",
+    "description": "Label for the Event Grid Columns"
+  },
+  "eventGrid.header.author": {
+    "message": "Auteur/Autrice",
+    "description": "Label for the Event Grid Columns"
+  },
+  "eventGrid.header.day": {
+    "message": "Jour",
+    "description": "Label for the Event Grid Columns"
+  },
+  "eventGrid.header.description": {
+    "message": "Mots-clés",
+    "description": "Label for the Event Grid Columns"
+  },
+  "eventGrid.header.start": {
+    "message": "Début",
+    "description": "Label for the Event Grid Columns"
+  },
+  "eventGrid.header.end": {
+    "message": "Fin",
+    "description": "Label for the Event Grid Columns"
+  },
+  "eventGrid.header.location": {
+    "message": "Lieu",
+    "description": "Label for the Event Grid Columns"
+  },
+  "eventGrid.header.userGroup": {
+    "message": "Groupe",
+    "description": "Label for the Event Grid Columns"
+  },
+  "eventGrid.header.departmens": {
+    "message": "Filières",
+    "description": "Label for the Event Grid Columns"
+  },
+  "eventGrid.header.classes": {
+    "message": "Classes",
+    "description": "Label for the Event Grid Columns"
+  },
+  "eventGrid.header.descriptionLong": {
+    "message": "Description",
+    "description": "Label for the Event Grid Columns"
+  },
+  "eventGrid.header.isDuplicate": {
+    "message": "Dupliquer",
+    "description": "Label for the Event Grid Columns"
+  },
+  "button.close.title": {
+    "message": "Fermer la Fenêtre",
+    "description": "Button title to close a modal"
+  },
+  "button.close": {
+    "message": "Fermer",
+    "description": "Button text to close a modal"
+  },
+  "TeachingAffected.YES.description": {
+    "message": "Oui",
+    "description": "Yes, the teaching is affected and the class is not present"
+  },
+  "TeachingAffected.NO.description": {
+    "message": "Non",
+    "description": "No, the teaching happens as usual"
+  },
+  "TeachingAffected.PARTIAL.description": {
+    "message": "Partiellement",
+    "description": "Only a part of the class will be present"
+  },
+  "EventAudience.ALL.description": {
+    "message": "Tout",
+    "description": "This event is for everyone, no matter wheter a lesson is affected or not"
+  },
+  "EventAudience.KLP.description": {
+    "message": "MC",
+    "description": "Only relevant (and displayed) for class teachers"
+  },
+  "EventAudience.LP.description": {
+    "message": "M",
+    "description": "Only relevant for teachers affected of this class (no matter wheter a lesson is affected or not)"
+  },
+  "EventAudience.STUDENTS.description": {
+    "message": "EL",
+    "description": "Relevant for SuS only, their KLP will be informed aswell"
+  },
+  "shared.AudiencePicker": {
+    "message": "Toutes les écoles",
+    "description": "Button text to toggle all schools on/off"
+  },
+  "Künftige Klassen": {
+    "message": "Futures classes"
+  },
+  "shared.AudiencePicker.Department": {
+    "message": "Tous",
+    "description": "toggle all departments"
+  },
+  "theme.admonition.warning": {
+    "message": "attention",
+    "description": "The default label used for the Warning admonition (:::warning)"
+  },
+  "theme.DocSidebarItem.expandCategoryAriaLabel": {
+    "message": "Étendre la barre latérale de la catégorie '{label}'",
+    "description": "The ARIA label to expand the sidebar category"
+  },
+  "theme.DocSidebarItem.collapseCategoryAriaLabel": {
+    "message": "Réduire la barre latérale de la catégorie '{label}'",
+    "description": "The ARIA label to collapse the sidebar category"
+  },
+  "theme.unlistedContent.title": {
+    "message": "Page non répertoriée",
+    "description": "The unlisted content banner title"
+  },
+  "theme.unlistedContent.message": {
+    "message": "Cette page est non répertoriée. Les moteurs de recherche ne vont pas l'indexer et seuls les utilisateurs·trices ayant un lien direct y ont accès.",
+    "description": "The unlisted content banner message"
   }
 }

--- a/i18n/fr/docusaurus-plugin-content-docs/current.json
+++ b/i18n/fr/docusaurus-plugin-content-docs/current.json
@@ -2,5 +2,17 @@
   "version.label": {
     "message": "Suivant",
     "description": "The label for version current"
+  },
+  "sidebar.tutorialSidebar.category.Scenes": {
+    "message": "Scenes",
+    "description": "The label for category Scenes in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.Services": {
+    "message": "Services",
+    "description": "The label for category Services in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.ics": {
+    "message": "ics",
+    "description": "The label for category ics in sidebar tutorialSidebar"
   }
 }

--- a/i18n/fr/docusaurus-theme-classic/footer.json
+++ b/i18n/fr/docusaurus-theme-classic/footer.json
@@ -1,6 +1,6 @@
 {
   "link.title.Admin": {
-    "message": "Admin",
+    "message": "Administration",
     "description": "The title of the footer links column with title=Admin in the footer"
   },
   "link.title.Dashboard": {
@@ -35,8 +35,36 @@
     "message": "GBJB",
     "description": "The label of footer link with label=GBJB linking to https://gfbienne.ch"
   },
+  "link.title.Events": {
+    "message": "Événements",
+    "description": "The title of the footer links column with title=Events in the footer"
+  },
+  "link.title.Links": {
+    "message": "Liens",
+    "description": "The title of the footer links column with title=Links in the footer"
+  },
+  "link.item.label.Kalender": {
+    "message": "Calendrier",
+    "description": "The label of footer link with label=Kalender linking to /calendar"
+  },
+  "link.item.label.Tabelle": {
+    "message": "Liste",
+    "description": "The label of footer link with label=Tabelle linking to /table"
+  },
+  "link.item.label.Gantt": {
+    "message": "Lignes de temps",
+    "description": "The label of footer link with label=Gantt linking to /gantt"
+  },
+  "link.item.label.Dokumentation": {
+    "message": "Documentation",
+    "description": "The label of footer link with label=Dokumentation linking to /docs"
+  },
+  "link.item.label.Socket.IO Dashboard": {
+    "message": "Socket.IO > Tableau de bord",
+    "description": "The label of footer link with label=Socket.IO Dashboard linking to https://admin.socket.io/"
+  },
   "copyright": {
-    "message": "Copyright © 2023 B. Hofer <br /><a class=\"badge badge--primary\" href=\"https://github.com/lebalz/events-app/commit/52va2m\">ᚶ 52va2m</a>",
+    "message": "Copyright © 2023 B. Hofer <br /><a class=\"badge badge--primary\" href=\"https://github.com/lebalz/events-app/commit/69819bc145d8cd29e5dddbd264cd330ce82b1f89\">ᚶ 69819bc</a>",
     "description": "The footer copyright"
   }
 }

--- a/i18n/fr/docusaurus-theme-classic/footer.json
+++ b/i18n/fr/docusaurus-theme-classic/footer.json
@@ -3,25 +3,9 @@
     "message": "Administration",
     "description": "The title of the footer links column with title=Admin in the footer"
   },
-  "link.title.Dashboard": {
-    "message": "Tableau de bord",
-    "description": "The title of the footer links column with title=Dashboard in the footer"
-  },
-  "link.title.More": {
-    "message": "Plus",
-    "description": "The title of the footer links column with title=More in the footer"
-  },
-  "link.item.label.Dashboard": {
-    "message": "Tableau de bord",
-    "description": "The label of footer link with label=Dashboard linking to /admin"
-  },
   "link.item.label.Import": {
     "message": "Importation",
     "description": "The label of footer link with label=Import linking to /import"
-  },
-  "link.item.label.Socket.IO Admin": {
-    "message": "Socket.IO Admin",
-    "description": "The label of footer link with label=Socket.IO Admin linking to https://admin.socket.io/"
   },
   "link.item.label.GBSL": {
     "message": "GBSL",
@@ -63,8 +47,8 @@
     "message": "Socket.IO > Tableau de bord",
     "description": "The label of footer link with label=Socket.IO Dashboard linking to https://admin.socket.io/"
   },
-  "copyright": {
-    "message": "Copyright © 2023 B. Hofer <br /><a class=\"badge badge--primary\" href=\"https://github.com/lebalz/events-app/commit/69819bc145d8cd29e5dddbd264cd330ce82b1f89\">ᚶ 69819bc</a>",
-    "description": "The footer copyright"
+  "link.item.label.Dashboard": {
+    "message": "Dashboard",
+    "description": "The label of footer link with label=Dashboard linking to /admin"
   }
 }

--- a/i18n/fr/docusaurus-theme-classic/navbar.json
+++ b/i18n/fr/docusaurus-theme-classic/navbar.json
@@ -24,7 +24,11 @@
     "description": "Navbar item with label Stupla"
   },
   "item.label.Meine": {
-    "message": "Mon",
+    "message": "Mon espace",
     "description": "Navbar item with label Meine"
+  },
+  "item.label.Zeitachse": {
+    "message": "Ligne du temps",
+    "description": "Navbar item with label Zeitachse"
   }
 }

--- a/i18n/fr/docusaurus-theme-classic/navbar.json
+++ b/i18n/fr/docusaurus-theme-classic/navbar.json
@@ -15,18 +15,6 @@
     "message": "Tableau",
     "description": "Navbar item with label Tabelle"
   },
-  "item.label.GANTT": {
-    "message": "GANTT",
-    "description": "Navbar item with label GANTT"
-  },
-  "item.label.Stupla": {
-    "message": "Stupla",
-    "description": "Navbar item with label Stupla"
-  },
-  "item.label.Meine": {
-    "message": "Mon espace",
-    "description": "Navbar item with label Meine"
-  },
   "item.label.Zeitachse": {
     "message": "Ligne du temps",
     "description": "Navbar item with label Zeitachse"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
+    "postwrite-translations": "node cleanup-translations.js",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
     "crowdin": "crowdin",

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -84,7 +84,7 @@ const Calendar = observer(() => {
                             work_week: translate({message : "Arbeitswoche", id:'calendar.button.workWeek' , description:'button label to display a work week'}),
                             yesterday: translate({message : "Gestern", id:'calendar.button.yesterday' , description:'button label to navigate to the previous day'}),
                             allDay: translate({message : "Ganzer Tag", id:'calendar.message.allDay' , description:'message if an event spans the whole day'}),
-                            showMore: total => translate({message : `+${total} weitere`, id:'calendar.button.plus' , description:'button label to show more events'})
+                            showMore: total => `+${total} ${translate({message : 'weitere', id:'calendar.button.plus' , description:'button label to show more events'})}`
                         }}
                     />
                 )}


### PR DESCRIPTION
@zerifah with this change, it is now possible to write the translations local, crowdin is not used at all (for the moment):

The translations can be found in the `i18n` folder. The `de` folder contains the german (default) translations. The `fr` folder contains the french translations.

Update the translations (after new `translate(...)` code was added) with:

```bash
# for german
yarn write-translations --locale de
# for french
yarn write-translations --locale fr
```

existing translations will not be overwritten, except you pass the `--overwrite` flag.

After updating the translations, make sure to update the new keys (you can see in git, which keys are new...)

To **start docusaurus with the new translations in e.g. french**, run:

```bash
yarn run start --locale fr
```
