### PR TITLE
persist current calendar view date and set the default time to 07:30

### DIFF
--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -32,19 +32,12 @@ const createTasks = createTransformer((events: Event[]) => {
 
 const Calendar = observer(() => {
     const viewStore = useStore('viewStore');
-    const {eventTable} = viewStore;
+    const { eventTable } = viewStore;
 
     const tasks = createTasks(eventTable.events);
-
-    const { defaultDate } = React.useMemo(
-        () => ({
-          defaultDate: moment().toDate(),
-        }),
-        []
-      );
     const eventStyleGetter = React.useMemo(() => {
         return (event, start, end, isSelected) => {
-            const style: React.CSSProperties = {  backgroundColor: event.backgroundColor };
+            const style: React.CSSProperties = { backgroundColor: event.backgroundColor };
             if (event.isDeleted) {
                 style.textDecoration = 'line-through';
             }
@@ -60,9 +53,10 @@ const Calendar = observer(() => {
                 {tasks.length > 0 && (
                     <BigCalendar
                         defaultView='week'
-                        defaultDate={defaultDate}
+                        defaultDate={new Date(viewStore.calendarViewDate)}
                         localizer={localizer}
                         events={tasks}
+                        scrollToTime={new Date(`${viewStore.calendarViewDate}T07:30:00`)}
                         startAccessor="start"
                         endAccessor="end"
                         style={{ height: '95vh' }}
@@ -70,24 +64,27 @@ const Calendar = observer(() => {
                             viewStore.setEventModalId(record.id)
                         }}
                         eventPropGetter={eventStyleGetter}
+                        onNavigate={(date) => {
+                            viewStore.setCalendarViewDate(date);
+                        }}
                         popup
                         messages={{
-                            next: translate({message : "Nächste", id:'calendar.button.nextWeek' , description:'button to show the next week on the calendar'}),
-                            previous: translate({message : "Vorherige", id:'calendar.button.previousWeek' , description:'button to show the previous week on the calendar'}),
-                            today: translate({message : "Heute", id:'calendar.button.today' , description:'button to show today on the calendar'}),
-                            month: translate({message : "Monat", id:'calendar.button.month' , description:'button to show the calendar by month'}),
-                            week: translate({message : "Woche", id:'calendar.button.week' , description:'button to show the calendar by week'}),
-                            day: translate({message : "Tag", id:'calendar.button.day' , description:'button to show the calendar by day'}),
-                            agenda: translate({message : "Agenda", id:'calendar.button.agenda' , description:'button to show the calendar as list'}),
-                            date: translate({message : "Datum", id:'calendar.field.date' , description:'title of the table for the date'}),
-                            time: translate({message : "Zeit", id:'calendar.field.time' , description:'title of the table for the time'}),
-                            event: translate({message : "Event", id:'calendar.field.event' , description:'title of the table for the event'}),
-                            noEventsInRange: translate({message : "Keine Events in diesem Zeitraum", id:'calendar.message.noevent' , description:'message if no event in time range'}),
-                            tomorrow: translate({message : "Morgen", id:'calendar.button.tomorrow' , description:'button label to navigate to the next day'}),
-                            work_week: translate({message : "Arbeitswoche", id:'calendar.button.workWeek' , description:'button label to display a work week'}),
-                            yesterday: translate({message : "Gestern", id:'calendar.button.yesterday' , description:'button label to navigate to the previous day'}),
-                            allDay: translate({message : "Ganzer Tag", id:'calendar.message.allDay' , description:'message if an event spans the whole day'}),
-                            showMore: total => `+${total} ${translate({message : 'weitere', id:'calendar.button.plus' , description:'button label to show more events'})}`
+                            next: translate({ message: "Nächste", id: 'calendar.button.nextWeek', description: 'button to show the next week on the calendar' }),
+                            previous: translate({ message: "Vorherige", id: 'calendar.button.previousWeek', description: 'button to show the previous week on the calendar' }),
+                            today: translate({ message: "Heute", id: 'calendar.button.today', description: 'button to show today on the calendar' }),
+                            month: translate({ message: "Monat", id: 'calendar.button.month', description: 'button to show the calendar by month' }),
+                            week: translate({ message: "Woche", id: 'calendar.button.week', description: 'button to show the calendar by week' }),
+                            day: translate({ message: "Tag", id: 'calendar.button.day', description: 'button to show the calendar by day' }),
+                            agenda: translate({ message: "Agenda", id: 'calendar.button.agenda', description: 'button to show the calendar as list' }),
+                            date: translate({ message: "Datum", id: 'calendar.field.date', description: 'title of the table for the date' }),
+                            time: translate({ message: "Zeit", id: 'calendar.field.time', description: 'title of the table for the time' }),
+                            event: translate({ message: "Event", id: 'calendar.field.event', description: 'title of the table for the event' }),
+                            noEventsInRange: translate({ message: "Keine Events in diesem Zeitraum", id: 'calendar.message.noevent', description: 'message if no event in time range' }),
+                            tomorrow: translate({ message: "Morgen", id: 'calendar.button.tomorrow', description: 'button label to navigate to the next day' }),
+                            work_week: translate({ message: "Arbeitswoche", id: 'calendar.button.workWeek', description: 'button label to display a work week' }),
+                            yesterday: translate({ message: "Gestern", id: 'calendar.button.yesterday', description: 'button label to navigate to the previous day' }),
+                            allDay: translate({ message: "Ganzer Tag", id: 'calendar.message.allDay', description: 'message if an event spans the whole day' }),
+                            showMore: total => `+${total} ${translate({ message: 'weitere', id: 'calendar.button.plus', description: 'button label to show more events' })}`
                         }}
                     />
                 )}

--- a/src/stores/ViewStores/index.ts
+++ b/src/stores/ViewStores/index.ts
@@ -47,7 +47,8 @@ export class ViewStore implements ResettableStore, LoadeableStore<any> {
     @observable
     icalListClassFilter = '';
 
-
+    @observable
+    calendarViewDate = (new Date()).toISOString().split('T')[0];
 
     expandedEventIds = observable.set<string>();
 
@@ -111,6 +112,11 @@ export class ViewStore implements ResettableStore, LoadeableStore<any> {
             }
         }
         return events;
+    }
+
+    @action
+    setCalendarViewDate(date: Date) {
+        this.calendarViewDate = date.toISOString().split('T')[0];
     }
 
     @action


### PR DESCRIPTION
@zerifah Fixes feedback from SIM and AND regarding the Calendar View:
- set the default time to 07:30 Uhr
- persists the currently viewed Day/Week/Month s.t. after a "wrong" search, the previous date is shown
